### PR TITLE
for issue #1: cuMemsetD8() 1 error

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -1,3 +1,10 @@
+* changes v2.00 -> v2.01:
+
+Type.: Bug
+File.: Host
+Desc.: Fix for a cuMemsetD8() 1 error in attacks different from mask attacks
+Issue: 1
+
 * changes v1.37 -> v2.00:
 
 Type: Project

--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -2695,7 +2695,10 @@ static void run_copy (hc_device_param_t *device_param, const uint pws_cnt)
   // clear some leftovers from previous run (maskfiles, etc)
 
   #ifdef _CUDA
-  hc_cuMemsetD8 (device_param->c_bfs, 0, device_param->c_bytes);
+  if (device_param->c_bfs != 0) // should be only true in this specific case: if (data.attack_kern == ATTACK_KERN_BF)
+  {
+    hc_cuMemsetD8 (device_param->c_bfs, 0, device_param->c_bytes);
+  }
   #endif
 
   if (data.attack_kern == ATTACK_KERN_STRAIGHT)


### PR DESCRIPTION
It is a problem specific to nvidia, problem did not affect mask attacks but possibly all other attack modes.

This shows where the problem relies and proposes a possible fix for it. Please review.

Tested with success on gtx 980 ti.

(btw: driver version should be irrelevant)