### PR TITLE
allow both enabling and disabling of restore point update (implemented with issue #10)

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -17512,7 +17512,6 @@ int main (int argc, char **argv)
 
         hc_thread_wait (devices_cnt, c_threads);
 
-
         local_free (c_threads);
 
         data.restore = 0;

--- a/src/shared.c
+++ b/src/shared.c
@@ -8364,11 +8364,23 @@ void bypass ()
 
 void stop_at_checkpoint ()
 {
-  if (data.devices_status != STATUS_RUNNING) return;
+  if (data.devices_status != STATUS_STOP_AT_CHECKPOINT)
+  {
+    if (data.devices_status != STATUS_RUNNING) return;
+  }
 
   // this feature only makes sense if --restore-disable was not specified
 
-  if (data.restore_disable == 0)
+  if (data.restore_disable == 1)
+  {
+    log_info ("WARNING: this feature is disabled when --restore-disable was specified");
+
+    return;
+  }
+
+  // check if monitoring of Restore Point updates should be enabled or disabled
+
+  if (data.devices_status != STATUS_STOP_AT_CHECKPOINT)
   {
     data.devices_status = STATUS_STOP_AT_CHECKPOINT;
 
@@ -8376,11 +8388,17 @@ void stop_at_checkpoint ()
 
     data.checkpoint_cur_words = get_lowest_words_done ();
 
-    log_info ("Checkpoint enabled, will quit when Restore Point updates next time");
+    log_info ("Checkpoint enabled: will quit at next Restore Point update");
   }
   else
   {
-    log_info ("WARNING: this feature is disabled when --restore-disable was specified");
+    data.devices_status = STATUS_RUNNING;
+
+    // reset the global value for checkpoint checks
+
+    data.checkpoint_cur_words = 0;
+
+    log_info ("Checkpoint disabled: Restore Point updates will no longer be monitored");
   }
 }
 


### PR DESCRIPTION
This is just an additional small feature to issue #10: also allow the user to disable a restore point monitoring check, i.e. with this extra feature the user can do both create a new check or disable the check if it is already there (but the user does not want it anymore).
Thx