### PR TITLE
fixed hardware monitor for amd/nv

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -90,7 +90,7 @@ void log_out (FILE *fp, const char *fmt, ...);
 void log_info (const char *fmt, ...);
 void log_error (const char *fmt, ...);
 
-#endif
-
 typedef uint32_t uint; // we should rename to u32, sooner or later, for consistency
 typedef uint64_t u64;
+
+#endif

--- a/include/ext_ADL.h
+++ b/include/ext_ADL.h
@@ -14,7 +14,7 @@ typedef int bool;
 
 #include <adl_sdk.h>
 
-//typedef int HM_ADAPTER;
+typedef int HM_ADAPTER_AMD;
 
 #ifdef _POSIX
 void *GetProcAddress (void *pLibrary, const char *name);

--- a/include/ext_dummy.h
+++ b/include/ext_dummy.h
@@ -8,6 +8,4 @@
 
 #include <common.h>
 
-typedef int HM_ADAPTER;
-
 #endif

--- a/include/ext_nvapi.h
+++ b/include/ext_nvapi.h
@@ -54,7 +54,7 @@
 
 #include <nvapi.h>
 
-//typedef NvPhysicalGpuHandle HM_ADAPTER;
+typedef NvPhysicalGpuHandle HM_ADAPTER_NV;
 
 int hc_NvAPI_EnumPhysicalGPUs (NvPhysicalGpuHandle nvGPUHandle[NVAPI_MAX_PHYSICAL_GPUS], NvU32 *pGpuCount);
 int hc_NvAPI_GPU_GetThermalSettings (NvPhysicalGpuHandle hPhysicalGpu, NvU32 sensorIndex, NV_GPU_THERMAL_SETTINGS *pThermalSettings);

--- a/include/ext_nvml.h
+++ b/include/ext_nvml.h
@@ -10,7 +10,7 @@
 
 #include <nvml.h>
 
-//typedef nvmlDevice_t HM_ADAPTER;
+typedef nvmlDevice_t HM_ADAPTER_NV;
 
 nvmlReturn_t hc_NVML_nvmlInit (void);
 nvmlReturn_t hc_NVML_nvmlShutdown (void);

--- a/include/ext_smi.h
+++ b/include/ext_smi.h
@@ -11,8 +11,6 @@
 #define SMI_OK    0
 #define SMI_NOBIN 1
 
-typedef int HM_ADAPTER;
-
 int hc_nvidia_smi (int dev, int *temperature, int *gpu);
 
 #endif

--- a/include/shared.h
+++ b/include/shared.h
@@ -2009,34 +2009,32 @@ void logfile_append (const char *fmt, ...);
 void fsync (int fd);
 #endif
 
-/*
-int hm_get_adapter_index (HM_ADAPTER nvGPUHandle[DEVICES_MAX]);
+int hm_get_adapter_index_nv (HM_ADAPTER_NV nvGPUHandle[DEVICES_MAX]);
 
-int get_adapters_num  (HM_LIB hm_dll, int *iNumberAdapters);
+int get_adapters_num_amd (HM_LIB hm_dll, int *iNumberAdapters);
 
-int hm_get_device_num (HM_LIB hm_dll, HM_ADAPTER hm_adapter_index, int *hm_device_num);
+int hm_get_device_num (HM_LIB hm_dll, HM_ADAPTER_AMD hm_adapter_index, int *hm_device_num);
 
 // void hm_get_opencl_busid_devid (hm_attrs_t *hm_device, uint opencl_num_devices, cl_device_id *devices);
 
-int hm_get_adapter_index (hm_attrs_t *hm_device, uint32_t *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo);
+int hm_get_adapter_index_amd (hm_attrs_t *hm_device, uint32_t *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo);
 
-LPAdapterInfo hm_get_adapter_info (HM_LIB hm_dll, int iNumberAdapters);
+LPAdapterInfo hm_get_adapter_info_amd (HM_LIB hm_dll, int iNumberAdapters);
 
 uint32_t *hm_get_list_valid_adl_adapters (int iNumberAdapters, int *num_adl_adapters, LPAdapterInfo lpAdapterInfo);
 
 int hm_get_overdrive_version  (HM_LIB hm_dll, hm_attrs_t *hm_device, uint32_t *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo);
 int hm_check_fanspeed_control (HM_LIB hm_dll, hm_attrs_t *hm_device, uint32_t *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo);
 
-void hm_close (HM_LIB hm_dll);
+void hm_close_amd (HM_LIB hm_dll);
 
-HM_LIB hm_init ();
+HM_LIB hm_init_amd ();
 
 int hm_get_temperature_with_device_id (const uint device_id);
 int hm_get_fanspeed_with_device_id    (const uint device_id);
 int hm_get_utilization_with_device_id (const uint device_id);
 
-int hm_set_fanspeed_with_device_id (const uint device_id, const int fanspeed);
-*/
+int hm_set_fanspeed_with_device_id_amd (const uint device_id, const int fanspeed);
 
 void myabort ();
 void myquit ();

--- a/include/types.h
+++ b/include/types.h
@@ -957,7 +957,10 @@ typedef struct __hc_device_param hc_device_param_t;
 
 typedef struct
 {
-//  HM_ADAPTER adapter_index;
+  union {
+    HM_ADAPTER_AMD amd;
+    HM_ADAPTER_NV  nv;
+  } adapter_index;
 
   int od_version;
 

--- a/src/shared.c
+++ b/src/shared.c
@@ -2633,9 +2633,8 @@ void fsync (int fd)
  * thermal
  */
 
-/*
 #ifdef _WIN
-int hm_get_adapter_index (HM_ADAPTER nvGPUHandle[DEVICES_MAX])
+int hm_get_adapter_index_nv (HM_ADAPTER_NV nvGPUHandle[DEVICES_MAX])
 {
   NvU32 pGpuCount;
 
@@ -2653,7 +2652,7 @@ int hm_get_adapter_index (HM_ADAPTER nvGPUHandle[DEVICES_MAX])
 #endif
 
 #ifdef LINUX
-int hm_get_adapter_index (HM_ADAPTER nvGPUHandle[DEVICES_MAX])
+int hm_get_adapter_index_nv (HM_ADAPTER_NV nvGPUHandle[DEVICES_MAX])
 {
   int pGpuCount = 0;
 
@@ -2680,7 +2679,7 @@ int hm_get_adapter_index (HM_ADAPTER nvGPUHandle[DEVICES_MAX])
 }
 #endif
 
-void hm_close (HM_LIB hm_dll)
+void hm_close_amd (HM_LIB hm_dll)
 {
   #ifdef _POSIX
   dlclose (hm_dll);
@@ -2691,7 +2690,7 @@ void hm_close (HM_LIB hm_dll)
   #endif
 }
 
-HM_LIB hm_init ()
+HM_LIB hm_init_amd ()
 {
   #ifdef _POSIX
   HM_LIB hm_dll = dlopen ("libatiadlxx.so", RTLD_LAZY | RTLD_GLOBAL);
@@ -2707,7 +2706,7 @@ HM_LIB hm_init ()
   return hm_dll;
 }
 
-int get_adapters_num (HM_LIB hm_dll, int *iNumberAdapters)
+int get_adapters_num_amd (HM_LIB hm_dll, int *iNumberAdapters)
 {
   if (hc_ADL_Adapter_NumberOfAdapters_Get (hm_dll, iNumberAdapters) != ADL_OK) return -1;
 
@@ -2721,6 +2720,7 @@ int get_adapters_num (HM_LIB hm_dll, int *iNumberAdapters)
   return 0;
 }
 
+/*
 int hm_show_performance_level (HM_LIB hm_dll, int iAdapterIndex)
 {
   ADLODPerformanceLevels *lpOdPerformanceLevels = NULL;
@@ -2754,8 +2754,9 @@ int hm_show_performance_level (HM_LIB hm_dll, int iAdapterIndex)
 
   return 0;
 }
+*/
 
-LPAdapterInfo hm_get_adapter_info (HM_LIB hm_dll, int iNumberAdapters)
+LPAdapterInfo hm_get_adapter_info_amd (HM_LIB hm_dll, int iNumberAdapters)
 {
   size_t AdapterInfoSize = iNumberAdapters * sizeof (AdapterInfo);
 
@@ -2766,6 +2767,7 @@ LPAdapterInfo hm_get_adapter_info (HM_LIB hm_dll, int iNumberAdapters)
   return lpAdapterInfo;
 }
 
+/*
 //
 // does not help at all, since AMD does not assign different bus id, device id when we have multi GPU setups
 //
@@ -2804,6 +2806,7 @@ void hm_get_opencl_busid_devid (hm_attrs_t *hm_device, uint opencl_num_devices, 
     hm_device[i].devid = device_topology.pcie.device;
   }
 }
+*/
 
 void hm_sort_adl_adapters_by_busid_devid (uint32_t *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo)
 {
@@ -3018,7 +3021,7 @@ int hm_get_overdrive_version (HM_LIB hm_dll, hm_attrs_t *hm_device, uint32_t *va
   return 0;
 }
 
-int hm_get_adapter_index (hm_attrs_t *hm_device, uint32_t *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo)
+int hm_get_adapter_index_amd (hm_attrs_t *hm_device, uint32_t *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo)
 {
   for (int i = 0; i < num_adl_adapters; i++)
   {
@@ -3036,7 +3039,7 @@ int hm_get_adapter_index (hm_attrs_t *hm_device, uint32_t *valid_adl_device_list
 
     int opencl_device_index = i;
 
-    hm_device[opencl_device_index].adapter_index = info.iAdapterIndex;
+    hm_device[opencl_device_index].adapter_index.amd = info.iAdapterIndex;
   }
 
   return num_adl_adapters;
@@ -3054,7 +3057,7 @@ int hm_get_temperature_with_device_id (const uint device_id)
 
         Temperature.iSize = sizeof (ADLTemperature);
 
-        if (hc_ADL_Overdrive5_Temperature_Get (data.hm_dll, data.hm_device[device_id].adapter_index, 0, &Temperature) != ADL_OK) return -1;
+        if (hc_ADL_Overdrive5_Temperature_Get (data.hm_dll, data.hm_device[device_id].adapter_index.amd, 0, &Temperature) != ADL_OK) return -1;
 
         return Temperature.iTemperature / 1000;
       }
@@ -3062,7 +3065,7 @@ int hm_get_temperature_with_device_id (const uint device_id)
       {
         int Temperature = 0;
 
-        if (hc_ADL_Overdrive6_Temperature_Get (data.hm_dll, data.hm_device[device_id].adapter_index, &Temperature) != ADL_OK) return -1;
+        if (hc_ADL_Overdrive6_Temperature_Get (data.hm_dll, data.hm_device[device_id].adapter_index.amd, &Temperature) != ADL_OK) return -1;
 
         return Temperature / 1000;
       }
@@ -3074,7 +3077,7 @@ int hm_get_temperature_with_device_id (const uint device_id)
     #ifdef LINUX
     int temperature = 0;
 
-    hc_NVML_nvmlDeviceGetTemperature (data.hm_device[device_id].adapter_index, NVML_TEMPERATURE_GPU, (unsigned int *) &temperature);
+    hc_NVML_nvmlDeviceGetTemperature (data.hm_device[device_id].adapter_index.nv, NVML_TEMPERATURE_GPU, (unsigned int *) &temperature);
 
     return temperature;
     #endif
@@ -3087,7 +3090,7 @@ int hm_get_temperature_with_device_id (const uint device_id)
     pThermalSettings.sensor[0].controller = NVAPI_THERMAL_CONTROLLER_UNKNOWN;
     pThermalSettings.sensor[0].target = NVAPI_THERMAL_TARGET_GPU;
 
-    if (hc_NvAPI_GPU_GetThermalSettings (data.hm_device[device_id].adapter_index, 0, &pThermalSettings) != NVAPI_OK) return -1;
+    if (hc_NvAPI_GPU_GetThermalSettings (data.hm_device[device_id].adapter_index.nv, 0, &pThermalSettings) != NVAPI_OK) return -1;
 
     return pThermalSettings.sensor[0].currentTemp;
     #endif
@@ -3114,7 +3117,7 @@ int hm_get_fanspeed_with_device_id (const uint device_id)
           lpFanSpeedValue.iSpeedType = ADL_DL_FANCTRL_SPEED_TYPE_PERCENT;
           lpFanSpeedValue.iFlags     = ADL_DL_FANCTRL_FLAG_USER_DEFINED_SPEED;
 
-          if (hc_ADL_Overdrive5_FanSpeed_Get (data.hm_dll, data.hm_device[device_id].adapter_index, 0, &lpFanSpeedValue) != ADL_OK) return -1;
+          if (hc_ADL_Overdrive5_FanSpeed_Get (data.hm_dll, data.hm_device[device_id].adapter_index.amd, 0, &lpFanSpeedValue) != ADL_OK) return -1;
 
           return lpFanSpeedValue.iFanSpeed;
         }
@@ -3124,7 +3127,7 @@ int hm_get_fanspeed_with_device_id (const uint device_id)
 
           memset (&faninfo, 0, sizeof (faninfo));
 
-          if (hc_ADL_Overdrive6_FanSpeed_Get (data.hm_dll, data.hm_device[device_id].adapter_index, &faninfo) != ADL_OK) return -1;
+          if (hc_ADL_Overdrive6_FanSpeed_Get (data.hm_dll, data.hm_device[device_id].adapter_index.amd, &faninfo) != ADL_OK) return -1;
 
           return faninfo.iFanSpeedPercent;
         }
@@ -3136,7 +3139,7 @@ int hm_get_fanspeed_with_device_id (const uint device_id)
       #ifdef LINUX
       int speed = 0;
 
-      hc_NVML_nvmlDeviceGetFanSpeed (data.hm_device[device_id].adapter_index, (unsigned int *) &speed);
+      hc_NVML_nvmlDeviceGetFanSpeed (data.hm_device[device_id].adapter_index.nv, (unsigned int *) &speed);
 
       return speed;
       #endif
@@ -3144,7 +3147,7 @@ int hm_get_fanspeed_with_device_id (const uint device_id)
       #ifdef WIN
       NvU32 speed = 0;
 
-      hc_NvAPI_GPU_GetTachReading (data.hm_device[device_id].adapter_index, &speed);
+      hc_NvAPI_GPU_GetTachReading (data.hm_device[device_id].adapter_index.nv, &speed);
 
       return speed;
       #endif
@@ -3164,18 +3167,18 @@ int hm_get_utilization_with_device_id (const uint device_id)
 
       PMActivity.iSize = sizeof (ADLPMActivity);
 
-      if (hc_ADL_Overdrive_CurrentActivity_Get (data.hm_dll, data.hm_device[device_id].adapter_index, &PMActivity) != ADL_OK) return -1;
+      if (hc_ADL_Overdrive_CurrentActivity_Get (data.hm_dll, data.hm_device[device_id].adapter_index.amd, &PMActivity) != ADL_OK) return -1;
 
       return PMActivity.iActivityPercent;
     }
   }
 
-  if (data.vendor_id == VENDOR_ID_AMD)
+  if (data.vendor_id == VENDOR_ID_NV)
   {
     #ifdef LINUX
     nvmlUtilization_t utilization;
 
-    hc_NVML_nvmlDeviceGetUtilizationRates (data.hm_device[device_id].adapter_index, &utilization);
+    hc_NVML_nvmlDeviceGetUtilizationRates (data.hm_device[device_id].adapter_index.nv, &utilization);
 
     return utilization.gpu;
     #endif
@@ -3185,7 +3188,7 @@ int hm_get_utilization_with_device_id (const uint device_id)
 
     pDynamicPstatesInfoEx.version = NV_GPU_DYNAMIC_PSTATES_INFO_EX_VER;
 
-    if (hc_NvAPI_GPU_GetDynamicPstatesInfoEx (data.hm_device[device_id].adapter_index, &pDynamicPstatesInfoEx) != NVAPI_OK) return -1;
+    if (hc_NvAPI_GPU_GetDynamicPstatesInfoEx (data.hm_device[device_id].adapter_index.nv, &pDynamicPstatesInfoEx) != NVAPI_OK) return -1;
 
     return pDynamicPstatesInfoEx.utilization[0].percentage;
     #endif
@@ -3194,7 +3197,7 @@ int hm_get_utilization_with_device_id (const uint device_id)
   return -1;
 }
 
-int hm_set_fanspeed_with_device_id (const uint device_id, const int fanspeed)
+int hm_set_fanspeed_with_device_id_amd (const uint device_id, const int fanspeed)
 {
   if (data.hm_device[device_id].fan_supported == 1)
   {
@@ -3211,7 +3214,7 @@ int hm_set_fanspeed_with_device_id (const uint device_id, const int fanspeed)
         lpFanSpeedValue.iFlags     = ADL_DL_FANCTRL_FLAG_USER_DEFINED_SPEED;
         lpFanSpeedValue.iFanSpeed  = fanspeed;
 
-        if (hc_ADL_Overdrive5_FanSpeed_Set (data.hm_dll, data.hm_device[device_id].adapter_index, 0, &lpFanSpeedValue) != ADL_OK) return -1;
+        if (hc_ADL_Overdrive5_FanSpeed_Set (data.hm_dll, data.hm_device[device_id].adapter_index.amd, 0, &lpFanSpeedValue) != ADL_OK) return -1;
 
         return 0;
       }
@@ -3224,7 +3227,7 @@ int hm_set_fanspeed_with_device_id (const uint device_id, const int fanspeed)
         fan_speed_value.iSpeedType = ADL_OD6_FANSPEED_TYPE_PERCENT;
         fan_speed_value.iFanSpeed  = fanspeed;
 
-        if (hc_ADL_Overdrive6_FanSpeed_Set (data.hm_dll, data.hm_device[device_id].adapter_index, &fan_speed_value) != ADL_OK) return -1;
+        if (hc_ADL_Overdrive6_FanSpeed_Set (data.hm_dll, data.hm_device[device_id].adapter_index.amd, &fan_speed_value) != ADL_OK) return -1;
 
         return 0;
       }
@@ -3233,7 +3236,6 @@ int hm_set_fanspeed_with_device_id (const uint device_id, const int fanspeed)
 
   return -1;
 }
-*/
 
 /**
  * maskprocessor


### PR DESCRIPTION
one problem that is still there since last commit: dynamic loading of libnvidia-ml)

The remaining parts should be back and working (but untested because of the lib loading problem).

This commit tries to reenable all the fan control and hardware monitoring features (including aborting when the GPU temperature is too high).