### PR TITLE
change in library loading: libnvidia-ml now does load dynamically

### DIFF
--- a/include/ext_nvml.h
+++ b/include/ext_nvml.h
@@ -12,13 +12,23 @@
 
 typedef nvmlDevice_t HM_ADAPTER_NV;
 
-nvmlReturn_t hc_NVML_nvmlInit (void);
-nvmlReturn_t hc_NVML_nvmlShutdown (void);
-nvmlReturn_t hc_NVML_nvmlDeviceGetName (nvmlDevice_t device, char *name, unsigned int length);
-nvmlReturn_t hc_NVML_nvmlDeviceGetHandleByIndex (unsigned int index, nvmlDevice_t *device);
-nvmlReturn_t hc_NVML_nvmlDeviceGetTemperature (nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp);
-nvmlReturn_t hc_NVML_nvmlDeviceGetFanSpeed (nvmlDevice_t device, unsigned int *speed);
-nvmlReturn_t hc_NVML_nvmlDeviceGetPowerUsage (nvmlDevice_t device, unsigned int *power);
-nvmlReturn_t hc_NVML_nvmlDeviceGetUtilizationRates (nvmlDevice_t device, nvmlUtilization_t *utilization);
+typedef const char * (*NVML_ERROR_STRING) (nvmlReturn_t);
+typedef int (*NVML_INIT) ();
+typedef int (*NVML_SHUTDOWN) ();
+typedef nvmlReturn_t (*NVML_DEVICE_GET_NAME) (nvmlDevice_t, char *, unsigned int);
+typedef nvmlReturn_t (*NVML_DEVICE_GET_HANDLE_BY_INDEX) (unsigned int, nvmlDevice_t *);
+typedef nvmlReturn_t (*NVML_DEVICE_GET_TEMPERATURE) (nvmlDevice_t, nvmlTemperatureSensors_t, unsigned int *);
+typedef nvmlReturn_t (*NVML_DEVICE_GET_FAN_SPEED) (nvmlDevice_t, unsigned int *);
+typedef nvmlReturn_t (*NVML_DEVICE_GET_POWER_USAGE) (nvmlDevice_t, unsigned int *);
+typedef nvmlReturn_t (*NVML_DEVICE_GET_UTILIZATION_RATES) (nvmlDevice_t, nvmlUtilization_t *);
+
+nvmlReturn_t hc_NVML_nvmlInit (HM_LIB hDLL);
+nvmlReturn_t hc_NVML_nvmlShutdown (HM_LIB hDLL);
+nvmlReturn_t hc_NVML_nvmlDeviceGetName (HM_LIB hDLL, nvmlDevice_t device, char *name, unsigned int length);
+nvmlReturn_t hc_NVML_nvmlDeviceGetHandleByIndex (HM_LIB hDLL, int, unsigned int index, nvmlDevice_t *device);
+nvmlReturn_t hc_NVML_nvmlDeviceGetTemperature (HM_LIB hDLL, nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp);
+nvmlReturn_t hc_NVML_nvmlDeviceGetFanSpeed (HM_LIB hDLL, int, nvmlDevice_t device, unsigned int *speed);
+nvmlReturn_t hc_NVML_nvmlDeviceGetPowerUsage (HM_LIB hDLL, nvmlDevice_t device, unsigned int *power);
+nvmlReturn_t hc_NVML_nvmlDeviceGetUtilizationRates (HM_LIB hDLL, nvmlDevice_t device, nvmlUtilization_t *utilization);
 
 #endif

--- a/include/shared.h
+++ b/include/shared.h
@@ -2026,9 +2026,9 @@ uint32_t *hm_get_list_valid_adl_adapters (int iNumberAdapters, int *num_adl_adap
 int hm_get_overdrive_version  (HM_LIB hm_dll, hm_attrs_t *hm_device, uint32_t *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo);
 int hm_check_fanspeed_control (HM_LIB hm_dll, hm_attrs_t *hm_device, uint32_t *valid_adl_device_list, int num_adl_adapters, LPAdapterInfo lpAdapterInfo);
 
-void hm_close_amd (HM_LIB hm_dll);
+void hm_close (HM_LIB hm_dll);
 
-HM_LIB hm_init_amd ();
+HM_LIB hm_init ();
 
 int hm_get_temperature_with_device_id (const uint device_id);
 int hm_get_fanspeed_with_device_id    (const uint device_id);

--- a/src/Makefile
+++ b/src/Makefile
@@ -98,7 +98,7 @@ CFLAGS_WIN               := -D_WIN   -DWIN -D__MSVCRT__ -D__USE_MINGW_ANSI_STDIO
 CFLAGS_LINUX		 += -I$(OCL)/include/ -I$(ADL)/include/ -I$(GDK)/usr/include/nvidia/gdk/
 CFLAGS_WIN		 += -I$(OCL)/include/ -I$(ADL)/include/ -I$(NVAPI)/
 
-LFLAGS_LINUX		 := -lpthread -lOpenCL -ldl -lnvidia-ml
+LFLAGS_LINUX		 := -lpthread -lOpenCL -ldl
 LFLAGS_WIN		 := -lpsapi -L./lib
 
 ##

--- a/src/ext_nvml.c
+++ b/src/ext_nvml.c
@@ -5,13 +5,43 @@
 
 #include <ext_nvml.h>
 
-nvmlReturn_t hc_NVML_nvmlInit (void)
+//#ifdef _POSIX // implied
+
+void *GetLibFunction (void *pLibrary, const char *name)
 {
+  return dlsym (pLibrary, name);
+}
+
+const char * hc_NVML_nvmlErrorString (HM_LIB hDLL, nvmlReturn_t nvml_rc)
+{
+  NVML_ERROR_STRING nvmlErrorString = (NVML_ERROR_STRING) GetLibFunction (hDLL, "nvmlErrorString");
+
+  if (nvmlErrorString == NULL)
+  {
+    log_error ("ERROR: %s\n", "nvmlErrorString() is missing");
+
+    exit (-1);
+  }
+
+  return nvmlErrorString (nvml_rc);
+}
+
+nvmlReturn_t hc_NVML_nvmlInit (HM_LIB hDLL)
+{
+  NVML_INIT nvmlInit = (NVML_INIT) GetLibFunction (hDLL, "nvmlInit");
+
+  if (nvmlInit == NULL)
+  {
+    log_error ("ERROR: %s\n", "nvmlInit() is missing");
+
+    exit (-1);
+  }
+
   nvmlReturn_t nvml_rc = nvmlInit ();
 
   if (nvml_rc != NVML_SUCCESS)
   {
-    const char *string = nvmlErrorString (nvml_rc);
+    const char *string = hc_NVML_nvmlErrorString (hDLL, nvml_rc);
 
     log_info ("WARN: %s %d %s\n", "nvmlInit()", nvml_rc, string);
   }
@@ -19,13 +49,22 @@ nvmlReturn_t hc_NVML_nvmlInit (void)
   return nvml_rc;
 }
 
-nvmlReturn_t hc_NVML_nvmlShutdown (void)
+nvmlReturn_t hc_NVML_nvmlShutdown (HM_LIB hDLL)
 {
+  NVML_SHUTDOWN nvmlShutdown = (NVML_SHUTDOWN) GetLibFunction (hDLL, "nvmlShutdown");
+
+  if (nvmlShutdown == NULL)
+  {
+    log_error ("ERROR: %s\n", "nvmlShutdown() is missing");
+
+    exit (-1);
+  }
+
   nvmlReturn_t nvml_rc = nvmlShutdown ();
 
   if (nvml_rc != NVML_SUCCESS)
   {
-    const char *string = nvmlErrorString (nvml_rc);
+    const char *string = hc_NVML_nvmlErrorString (hDLL, nvml_rc);
 
     log_info ("WARN: %s %d %s\n", "nvmlShutdown()", nvml_rc, string);
   }
@@ -33,13 +72,22 @@ nvmlReturn_t hc_NVML_nvmlShutdown (void)
   return nvml_rc;
 }
 
-nvmlReturn_t hc_NVML_nvmlDeviceGetName (nvmlDevice_t device, char *name, unsigned int length)
+nvmlReturn_t hc_NVML_nvmlDeviceGetName (HM_LIB hDLL, nvmlDevice_t device, char *name, unsigned int length)
 {
+  NVML_DEVICE_GET_NAME nvmlDeviceGetName = (NVML_DEVICE_GET_NAME) GetLibFunction (hDLL, "nvmlDeviceGetName");
+
+  if (nvmlDeviceGetName == NULL)
+  {
+    log_error ("ERROR: %s\n", "nvmlDeviceGetName() is missing");
+
+    exit (-1);
+  }
+
   nvmlReturn_t nvml_rc = nvmlDeviceGetName (device, name, length);
 
   if (nvml_rc != NVML_SUCCESS)
   {
-    const char *string = nvmlErrorString (nvml_rc);
+    const char *string = hc_NVML_nvmlErrorString (hDLL, nvml_rc);
 
     log_info ("WARN: %s %d %s\n", "nvmlDeviceGetName()", nvml_rc, string);
   }
@@ -47,29 +95,50 @@ nvmlReturn_t hc_NVML_nvmlDeviceGetName (nvmlDevice_t device, char *name, unsigne
   return nvml_rc;
 }
 
-nvmlReturn_t hc_NVML_nvmlDeviceGetHandleByIndex (unsigned int index, nvmlDevice_t *device)
+nvmlReturn_t hc_NVML_nvmlDeviceGetHandleByIndex (HM_LIB hDLL, int skip_warnings, unsigned int index, nvmlDevice_t *device)
 {
+  NVML_DEVICE_GET_HANDLE_BY_INDEX nvmlDeviceGetHandleByIndex = (NVML_DEVICE_GET_HANDLE_BY_INDEX) GetLibFunction (hDLL, "nvmlDeviceGetHandleByIndex");
+
+  if (nvmlDeviceGetHandleByIndex == NULL)
+  {
+    log_error ("ERROR: %s\n", "nvmlDeviceGetHandleByIndex() is missing");
+
+    exit (-1);
+  }
+
   nvmlReturn_t nvml_rc = nvmlDeviceGetHandleByIndex (index, device);
 
   if (nvml_rc != NVML_SUCCESS)
   {
-    const char *string = nvmlErrorString (nvml_rc);
+    if (skip_warnings == 0)
+    {
+      const char *string = hc_NVML_nvmlErrorString (hDLL, nvml_rc);
 
-    log_info ("WARN: %s %d %s\n", "nvmlDeviceGetHandleByIndex()", nvml_rc, string);
+      log_info ("WARN: %s %d %s\n", "nvmlDeviceGetHandleByIndex()", nvml_rc, string);
+    }
   }
 
   return nvml_rc;
 }
 
-nvmlReturn_t hc_NVML_nvmlDeviceGetTemperature (nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp)
+nvmlReturn_t hc_NVML_nvmlDeviceGetTemperature (HM_LIB hDLL, nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp)
 {
+  NVML_DEVICE_GET_TEMPERATURE nvmlDeviceGetTemperature = (NVML_DEVICE_GET_TEMPERATURE) GetLibFunction (hDLL, "nvmlDeviceGetTemperature");
+
+  if (nvmlDeviceGetTemperature == NULL)
+  {
+    log_error ("ERROR: %s\n", "nvmlDeviceGetTemperature() is missing");
+
+    exit (-1);
+  }
+
   nvmlReturn_t nvml_rc = nvmlDeviceGetTemperature (device, sensorType, temp);
 
   if (nvml_rc != NVML_SUCCESS)
   {
     *temp = -1;
 
-    //const char *string = nvmlErrorString (nvml_rc);
+    //const char *string = hc_NVML_nvmlErrorString (hDLL, nvml_rc);
 
     //log_info ("WARN: %s %d %s\n", "nvmlDeviceGetTemperature()", nvml_rc, string);
   }
@@ -77,17 +146,29 @@ nvmlReturn_t hc_NVML_nvmlDeviceGetTemperature (nvmlDevice_t device, nvmlTemperat
   return nvml_rc;
 }
 
-nvmlReturn_t hc_NVML_nvmlDeviceGetFanSpeed (nvmlDevice_t device, unsigned int *speed)
+nvmlReturn_t hc_NVML_nvmlDeviceGetFanSpeed (HM_LIB hDLL, int skip_warnings, nvmlDevice_t device, unsigned int *speed)
 {
+  NVML_DEVICE_GET_FAN_SPEED nvmlDeviceGetFanSpeed = (NVML_DEVICE_GET_FAN_SPEED) GetLibFunction (hDLL, "nvmlDeviceGetFanSpeed");
+
+  if (nvmlDeviceGetFanSpeed == NULL)
+  {
+    log_error ("ERROR: %s\n", "nvmlDeviceGetFanSpeed() is missing");
+
+    exit (-1);
+  }
+
   nvmlReturn_t nvml_rc = nvmlDeviceGetFanSpeed (device, speed);
 
   if (nvml_rc != NVML_SUCCESS)
   {
     *speed = -1;
 
-    //const char *string = nvmlErrorString (nvml_rc);
+    if (skip_warnings == 0)
+    {
+      const char *string = hc_NVML_nvmlErrorString (hDLL, nvml_rc);
 
-    //log_info ("WARN: %s %d %s\n", "nvmlDeviceGetFanSpeed()", nvml_rc, string);
+      log_info ("WARN: %s %d %s\n", "nvmlDeviceGetFanSpeed()", nvml_rc, string);
+    }
   }
 
   return nvml_rc;
@@ -95,15 +176,24 @@ nvmlReturn_t hc_NVML_nvmlDeviceGetFanSpeed (nvmlDevice_t device, unsigned int *s
 
 /* only tesla following */
 
-nvmlReturn_t hc_NVML_nvmlDeviceGetPowerUsage (nvmlDevice_t device, unsigned int *power)
+nvmlReturn_t hc_NVML_nvmlDeviceGetPowerUsage (HM_LIB hDLL, nvmlDevice_t device, unsigned int *power)
 {
+  NVML_DEVICE_GET_POWER_USAGE nvmlDeviceGetPowerUsage = (NVML_DEVICE_GET_POWER_USAGE) GetLibFunction (hDLL, "nvmlDeviceGetPowerUsage");
+
+  if (nvmlDeviceGetPowerUsage == NULL)
+  {
+    log_error ("ERROR: %s\n", "nvmlDeviceGetPowerUsage() is missing");
+
+    exit (-1);
+  }
+
   nvmlReturn_t nvml_rc = nvmlDeviceGetPowerUsage (device, power);
 
   if (nvml_rc != NVML_SUCCESS)
   {
     *power = -1;
 
-    //const char *string = nvmlErrorString (nvml_rc);
+    //const char *string = hc_NVML_nvmlErrorString (hDLL, nvml_rc);
 
     //log_info ("WARN: %s %d %s\n", "nvmlDeviceGetPowerUsage()", nvml_rc, string);
   }
@@ -111,8 +201,17 @@ nvmlReturn_t hc_NVML_nvmlDeviceGetPowerUsage (nvmlDevice_t device, unsigned int 
   return nvml_rc;
 }
 
-nvmlReturn_t hc_NVML_nvmlDeviceGetUtilizationRates (nvmlDevice_t device, nvmlUtilization_t *utilization)
+nvmlReturn_t hc_NVML_nvmlDeviceGetUtilizationRates (HM_LIB hDLL, nvmlDevice_t device, nvmlUtilization_t *utilization)
 {
+  NVML_DEVICE_GET_UTILIZATION_RATES nvmlDeviceGetUtilizationRates = (NVML_DEVICE_GET_UTILIZATION_RATES) GetLibFunction (hDLL, "nvmlDeviceGetUtilizationRates");
+
+  if (nvmlDeviceGetUtilizationRates == NULL)
+  {
+    log_error ("ERROR: %s\n", "nvmlDeviceGetUtilizationRates() is missing");
+
+    exit (-1);
+  }
+
   nvmlReturn_t nvml_rc = nvmlDeviceGetUtilizationRates (device, utilization);
 
   if (nvml_rc != NVML_SUCCESS)
@@ -120,10 +219,12 @@ nvmlReturn_t hc_NVML_nvmlDeviceGetUtilizationRates (nvmlDevice_t device, nvmlUti
     utilization->gpu    = -1;
     utilization->memory = -1;
 
-    //const char *string = nvmlErrorString (nvml_rc);
+    //const char *string = hc_NVML_nvmlErrorString (hDLL, nvml_rc);
 
     //log_info ("WARN: %s %d %s\n", "nvmlDeviceGetUtilizationRates()", nvml_rc, string);
   }
 
   return nvml_rc;
 }
+
+//#endif

--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -12252,7 +12252,11 @@ int main (int argc, char **argv)
       if (vendor_id == VENDOR_ID_NV)
       {
         #ifdef LINUX
-        if (hc_NVML_nvmlInit () == NVML_SUCCESS)
+        HM_LIB hm_dll = hm_init ();
+
+        data.hm_dll = hm_dll;
+
+        if (hc_NVML_nvmlInit (hm_dll) == NVML_SUCCESS)
         {
           HM_ADAPTER_NV nvGPUHandle[DEVICES_MAX];
 
@@ -12271,7 +12275,7 @@ int main (int argc, char **argv)
           {
             unsigned int speed;
 
-            if (nvmlDeviceGetFanSpeed (hm_adapter_all[i].adapter_index.nv, &speed) != NVML_ERROR_NOT_SUPPORTED) hm_adapter_all[i].fan_supported = 1;
+            if (hc_NVML_nvmlDeviceGetFanSpeed (hm_dll, 1, hm_adapter_all[i].adapter_index.nv, &speed) != NVML_ERROR_NOT_SUPPORTED) hm_adapter_all[i].fan_supported = 1;
           }
         }
         #endif
@@ -12304,7 +12308,7 @@ int main (int argc, char **argv)
 
       if (vendor_id == VENDOR_ID_AMD)
       {
-        HM_LIB hm_dll = hm_init_amd ();
+        HM_LIB hm_dll = hm_init ();
 
         data.hm_dll = hm_dll;
 
@@ -16048,7 +16052,7 @@ int main (int argc, char **argv)
       if (vendor_id == VENDOR_ID_NV)
       {
         #ifdef LINUX
-        hc_NVML_nvmlShutdown ();
+        hc_NVML_nvmlShutdown (data.hm_dll);
         #endif
 
         #ifdef WIN
@@ -16060,8 +16064,15 @@ int main (int argc, char **argv)
       {
         hc_ADL_Main_Control_Destroy (data.hm_dll);
 
-        hm_close_amd (data.hm_dll);
+        hm_close (data.hm_dll);
       }
+
+      #ifdef LINUX
+      if (vendor_id == VENDOR_ID_NV)
+      {
+        hm_close (data.hm_dll);
+      }
+      #endif
     }
 
     // free memory


### PR DESCRIPTION
This only happens on nvidia systems (systems with nvidia GPUS installed), libnvidia-ml will now load dynamically if the system is running posix and has Nvidia installed.

We had to do this change because otherwise even AMD users need to have libnvidia-ml on there system (and in that case it would get loaded too even if not necessary).