### PR TITLE
limit the salt length of -m 22 = Juniper Netscreen/SSG (ScreenOS) to 10

### DIFF
--- a/src/shared.c
+++ b/src/shared.c
@@ -9622,7 +9622,8 @@ int netscreen_parse_hash (char *input_buf, uint input_len, hash_t *hash_buf)
 
   salt_len = parse_and_store_salt (salt_buf_ptr, salt_buf, salt_len);
 
-  if (salt_len == UINT_MAX) return (PARSER_SALT_LENGTH);
+  // max. salt length: salt_buf[32] => 32 - 22 (":Administration Tools:") = 10
+  if (salt_len > 10) return (PARSER_SALT_LENGTH);
 
   salt->salt_len = salt_len;
 

--- a/tools/test.pl
+++ b/tools/test.pl
@@ -2516,7 +2516,7 @@ sub passthrough
     }
     elsif ($mode == 22)
     {
-      my $salt_len = get_random_num (1, 15);
+      my $salt_len = get_random_num (1, 11);
 
       $tmp_hash = gen_hash ($mode, $word_buf, substr ($salt_buf, 0, $salt_len));
     }


### PR DESCRIPTION
The parser (and tests) of oclHashcat did not enforce the limit for -m 22 = Juniper Netscreen/SSG (ScreenOS) to length 10. This is needed since we have a salt buffer of length 32 and we always need to append 22 characters to the salt (":Administration Tools:").
Thx