### PR TITLE
fixed minor display problem in usage

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -600,7 +600,7 @@ const char *USAGE_BIG[] =
   "  12300 = Oracle T: Type (Oracle 12+)",
   "   8000 = Sybase ASE",
   "",
-  "[[ HTTP, SMTP, LDAP Server]]",
+  "[[ HTTP, SMTP, LDAP Server ]]",
   "",
   "    141 = EPiServer 6.x < v4",
   "   1441 = EPiServer 6.x > v4",


### PR DESCRIPTION
There was a minor typo/display problem in the usage (--help output).
The same problem was fixed within a commit in cpu hashcat (PR): https://github.com/philsmd/hashcat/commit/98028bd6a0dd4ea3e1ccc963a8bb3c8a9516fca9

Thx