### PR TITLE
issue #38: NVIDIA SDK is not needed anymore

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -11,11 +11,10 @@ oclHashcat build documentation
 
 To compile **oclHashcat** the following third party libraries are required:
 
-- ADL_SDK v8.0 ( http://developer.amd.com/tools-and-sdks/graphics-development/display-library-adl-sdk/ )
-- GDK v352_55 ( https://developer.nvidia.com/gpu-deployment-kit )
-- NVIDIA Driver v352.21 ( https://www.nvidia.com/download/driverResults.aspx/86390/en-us )
-- NVAPI R352 ( https://developer.nvidia.com/nvapi )
 - AMD-APP-SDK v3.0 ( http://developer.amd.com/tools-and-sdks/opencl-zone/amd-accelerated-parallel-processing-app-sdk/ )
+- ADL_SDK v8.0 ( http://developer.amd.com/tools-and-sdks/graphics-development/display-library-adl-sdk/ )
+- NVAPI R352 ( https://developer.nvidia.com/nvapi )
+- GDK v352_55 ( https://developer.nvidia.com/gpu-deployment-kit )
 
 To be able to compile the ocl binaries, it is required to have the latest stable driver from AMD installed.
 (fglxr must be installed and initialized)
@@ -28,7 +27,6 @@ The following files are needed inside the *deps/tmp* directory:
     
     ADL_SDK8.zip
     R352-developer.zip
-    NVIDIA-Linux-x86_64-352.21.run
     gdk_linux_amd64_352_55_release.run
     AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2
     

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,9 +36,6 @@ DOCUMENT_FOLDER          ?= /opt/test/usr/share/doc/oclHashcat
 ## Main SDK
 ##
 
-FORCEWARELIBPATH32       := deps/NVIDIA-Linux-x86_64-352.21/32
-FORCEWARELIBPATH64       := deps/NVIDIA-Linux-x86_64-352.21
-
 AMDAPP                   := deps/amd-app-sdk
 AMDAPPLIBPATH32          := $(AMDAPP)/lib/x86
 AMDAPPLIBPATH64          := $(AMDAPP)/lib/x86_64
@@ -56,8 +53,6 @@ OCLLIBPATH32             := $(AMDAPPLIBPATH32)
 OCLLIBPATH64             := $(AMDAPPLIBPATH64)
 
 NVML                     := $(GDK)/usr/include/nvidia/gdk
-NVMLLIBPATH32            := $(FORCEWARELIBPATH32)
-NVMLLIBPATH64            := $(FORCEWARELIBPATH64)
 
 CLCOMPILE_PATH           := tools/clcompile
 RULES_OPTIMIZE_PATH      := tools/rules_optimize

--- a/tools/deps.sh
+++ b/tools/deps.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Author: Gabriele Gristina <matrix@hashcat.net>
-# Revision: 1.02
+# Revision: 1.03
 
 ## global vars
 DEPS="make gcc g++ gcc-multilib g++-multilib libc6-dev-i386 mingw-w64 build-essential unzip"
-DOWNLOAD_DEPS="ADL_SDK8.zip R352-developer.zip NVIDIA-Linux-x86_64-352.21.run gdk_linux_amd64_352_55_release.run AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2"
+DOWNLOAD_DEPS="ADL_SDK8.zip R352-developer.zip gdk_linux_amd64_352_55_release.run AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2"
 
 ## enter the deps directory
 cur_directory=$(dirname ${0})
@@ -15,8 +15,8 @@ mkdir -p ${deps_dir} # but it should already exist (is part of the repository)
 cd ${deps_dir}
 
 ## cleanup the directories under the 'deps' folder
-rm -rf {adl-sdk,NVIDIA-Linux-x86_64-352.21,nvidia-gdk,amd-app-sdk} && \
-mkdir -p {tmp,adl-sdk,NVIDIA-Linux-x86_64-352.21,nvidia-gdk,amd-app-sdk} && \
+rm -rf {adl-sdk,nvidia-gdk,amd-app-sdk} && \
+mkdir -p {tmp,adl-sdk,nvidia-gdk,amd-app-sdk} && \
 cd tmp/
 
 if [ $? -ne 0 ]; then
@@ -83,21 +83,6 @@ if [[ ${ret} -ne 0 ]] && [[ ${ret} -ne 1 ]]; then
   exit 1
 fi
 
-## install NVIDIA Driver
-chmod +x NVIDIA-Linux-x86_64-352.21.run && \
-./NVIDIA-Linux-x86_64-352.21.run -x && \
-mv NVIDIA-Linux-x86_64-352.21 ${deps_dir}/ && \
-cd ${deps_dir}/NVIDIA-Linux-x86_64-352.21 && \
-ln -s libnvidia-ml.so.352.21 libnvidia-ml.so && \
-cd 32 && \
-ln -s libnvidia-ml.so.352.21 libnvidia-ml.so && \
-cd ${deps_dir}/tmp
-
-if [ $? -ne 0 ]; then
-  echo "! failed to install NVIDIA Driver"
-  exit 1
-fi
-
 ## install NVIDIA GPU Deployment Kit
 chmod +x gdk_linux_amd64_352_55_release.run && \
 ./gdk_linux_amd64_352_55_release.run --silent --installdir=${deps_dir}/nvidia-gdk
@@ -117,6 +102,7 @@ if [ $? -ne 0 ]; then
 fi
 
 rm -rf ${deps_dir}/amd-app-sdk && ln -s ${deps_dir}/amd-app-sdk-v3.0.130.135 ${deps_dir}/amd-app-sdk
+rm -rf ${deps_dir}/tmp/AMD-APP-SDK-v3.0.130.135-GA-linux64.sh
 
 if [ $? -ne 0 ]; then
   echo "! failed to setup ADL SDK link"


### PR DESCRIPTION
The NVML lib is dynamically loaded on Nvidia systems, therefore there is no need (anymore) that the devs install it on the dev system (the required library ships with the driver anyway).

Thanks