### PR TITLE
fixed tab completion to work with 64.bin, 32.bin and just oclHashcat binaries

### DIFF
--- a/extra/tab_completion/howto.txt
+++ b/extra/tab_completion/howto.txt
@@ -1,4 +1,4 @@
 run:
 source ./install
 OR
-source ./oclHashcat64.sh # not working permanently (not working anymore after a reboot etc)
+source ./oclHashcat.sh # not working permanently (i.e. not working after a reboot)

--- a/extra/tab_completion/install
+++ b/extra/tab_completion/install
@@ -5,7 +5,7 @@
 
 COMPGENSCRIPT=/etc/bash_completion
 COMPGENFOLDER=${COMPGENSCRIPT}.d
-COMPGENTARGET=${COMPGENFOLDER}/oclHashcat64.sh
+COMPGENTARGET=${COMPGENFOLDER}/oclHashcat.sh
 BASHRC=~/.bashrc
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -131,7 +131,7 @@ if [ -d "${COMPGENFOLDER}" ]; then
 
   # copy the script to target folder
 
-  cp ${ROOT}/oclHashcat64.sh "${COMPGENTARGET}"
+  cp ${ROOT}/oclHashcat.sh "${COMPGENTARGET}"
 
   # adjust paths to the main binaries of oclHashcat
 

--- a/extra/tab_completion/oclHashcat.sh
+++ b/extra/tab_completion/oclHashcat.sh
@@ -742,4 +742,4 @@ _oclHashcat ()
     esac
 }
 
-complete -F _oclHashcat -o filenames "${OCLHASHCAT_ROOT}"/oclHashcat64.bin "${OCLHASHCAT_ROOT}"/oclHashcat32.bin
+complete -F _oclHashcat -o filenames "${OCLHASHCAT_ROOT}"/oclHashcat64.bin "${OCLHASHCAT_ROOT}"/oclHashcat32.bin oclHashcat


### PR DESCRIPTION
Since we now allow the user to use "sudo make install", tab-completion had to be updated to work also with just "oclHashcat ..." in the command line.
This patch addresses this problem and in addition to that it changes the name of the bash complete script to "oclHashcat.sh" (was oclHashcat64.bin) such that it is more clear that this script works for all three variants: oclHashcat64.bin, oclHashcat32.bin and oclHashcat
Thx