### PR TITLE
fixed typo in tools/deps.sh

### DIFF
--- a/tools/deps.sh
+++ b/tools/deps.sh
@@ -17,7 +17,7 @@ cd ${deps_dir}
 
 ## cleanup the directories under the 'deps' folder
 rm -rf {adl-sdk*,nvidia-gdk,R352-developer} && \
-mkdir -p {tmp,adl-sdk*,nvidia-gdk,R352-developer} && \
+mkdir -p {tmp,adl-sdk,nvidia-gdk,R352-developer} && \
 cd tmp/
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
there was a typo in tools/deps.sh introduced with: dc13c2fc71c8c9e3af66ceaa9dfc8ff34cb56bfb
The folder name should be "adl-sdk" and not "adl-sdk*".
Thanks