### PR TITLE
this patch makes it much clearer where sessions under ~/.hashcat are located

### DIFF
--- a/include/shared.h
+++ b/include/shared.h
@@ -1925,7 +1925,7 @@ void truecrypt_crc32 (char *file, unsigned char keytab[64]);
 char *get_exec_path   ();
 char *get_install_dir (const char *progname);
 char *get_profile_dir (const char *homedir);
-char *get_session_dir (const char *profile_dir, const char *session);
+char *get_session_dir (const char *profile_dir);
 
 uint get_vliw_by_compute_capability (const uint major, const uint minor);
 uint get_vliw_by_device_name (const char *device_name);

--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -5333,7 +5333,7 @@ int main (int argc, char **argv)
     const char *homedir = pw->pw_dir;
 
     profile_dir = get_profile_dir (homedir);
-    session_dir = get_session_dir (profile_dir, session);
+    session_dir = get_session_dir (profile_dir);
     shared_dir  = strdup (SHARED_FOLDER);
 
     mkdir (profile_dir, 0700);

--- a/src/shared.c
+++ b/src/shared.c
@@ -4132,11 +4132,13 @@ char *get_profile_dir (const char *homedir)
   return profile_dir;
 }
 
-char *get_session_dir (const char *profile_dir, const char *session)
+char *get_session_dir (const char *profile_dir)
 {
-  char *session_dir = (char *) mymalloc (strlen (profile_dir) + 1 + strlen (session) + 1);
+  #define SESSIONS_FOLDER "sessions"
 
-  sprintf (session_dir, "%s/%s", profile_dir, session);
+  char *session_dir = (char *) mymalloc (strlen (profile_dir) + 1 + strlen (SESSIONS_FOLDER) + 1);
+
+  sprintf (session_dir, "%s/%s", profile_dir, SESSIONS_FOLDER);
 
   return session_dir;
 }


### PR DESCRIPTION
The problem was that it wasn't very clear that e.g. ~/.hashcat/oclHashcat/ is the (default) session folder or if I use --session abc that the sessions are located under ~/.hashcat/abc/.

With this patch the sessions are located under ~/.hashcat/sessions/ . This should be much more easy to understand what this folder is used for.
Under this folder (~/.hashcat/sessions/) there will be placed files such as $session.pot, $session.restore, $session.log etc
Thanks