### PR TITLE
minor: .gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 *.exe
 *.bin
 *.app
+oclHashcat
 *.restore
 *.dictstat
 *.pot
 *.log
-deps/*
 deps/**
+kernels/**
 lib/*.a
 obj/*.o


### PR DESCRIPTION
this patch just updates the .gitignore file such that files in deps/, kernels/ and the new binary "oclHashcat" are ignored by i.e. "git status".
(note: the ** does ignore files with 0 to indefinite depth, so we do *NOT* need both deps/* and deps**) 
Thanks