### PR TITLE
using oclHashcat instead of oclHashcat64.bin also in tools/test.pl

### DIFF
--- a/tools/test.pl
+++ b/tools/test.pl
@@ -40,7 +40,7 @@ use Net::DNS::RR::NSEC3;
 use Convert::EBCDIC qw (ascii2ebcdic);
 use Digest::SipHash qw/siphash/;
 
-my $hashcat = "./oclHashcat64.bin";
+my $hashcat = "./oclHashcat";
 
 my $MAX_LEN = 55;
 


### PR DESCRIPTION
Since we did replace ./oclHashcat64.bin with ./oclHashcat kind of everywhere in the source code, I suggest that we also should update tools/test.pl s.t. the native binary "oclHashcat" is used there too.
Thanks