### PR TITLE
the example*.sh files should now also use the native binary

### DIFF
--- a/example0.sh
+++ b/example0.sh
@@ -1,1 +1,1 @@
-./oclHashcat64.bin -t 32 -a 7 example0.hash ?a?a?a?a example.dict
+./oclHashcat -t 32 -a 7 example0.hash ?a?a?a?a example.dict

--- a/example400.sh
+++ b/example400.sh
@@ -1,1 +1,1 @@
-cat example.dict | ./oclHashcat64.bin -m 400 example400.hash
+cat example.dict | ./oclHashcat -m 400 example400.hash

--- a/example500.sh
+++ b/example500.sh
@@ -1,1 +1,1 @@
-./oclHashcat64.bin -m 500 example500.hash example.dict
+./oclHashcat -m 500 example500.hash example.dict

--- a/tools/package_bin.sh
+++ b/tools/package_bin.sh
@@ -24,11 +24,19 @@ cp -r $IN/rules                                 $OUT/
 cp -r $IN/extra                                 $OUT/
 cp    $IN/example.dict                          $OUT/
 cp    $IN/example[0123456789]*.hash             $OUT/
-cp    $IN/example[0123456789]*.sh               $OUT/
 cp    $IN/example[0123456789]*.cmd              $OUT/
 
 cp -r $IN/include                               $OUT/
 cp -r $IN/OpenCL                                $OUT/
+
+# since for the binary distribution we still use .bin, we need to rewrite the commands
+# within the example*.sh files
+
+for example in example[0123456789]*.sh; do
+
+  sed 's!./oclHashcat !./oclHashcat64.bin !' $IN/${example} > $OUT/${example}
+
+done
 
 dos2unix $OUT/rules/*.rule
 dos2unix $OUT/rules/hybrid/*.rule


### PR DESCRIPTION
Only when we use the packaging script we need to rewrite the commands such that the 64.bin version is used.

This allows us to use "oclHashcat" within the example*.sh on git but when we build the binary package (.7z for hashcat.net/oclHashcat ) we use "oclHashcat64.bin".

This way, the user can simply clone the repo, use "make" to build the project and hence the oclHashcat binary and after that he can execute e.g. ./example0.sh without any error. 