### PR TITLE
update for the build instructions with the notes about OpenCL-Headers

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -36,21 +36,31 @@ $ cd oclHashcat
 $ sudo ./tools/deps.sh
 ```
 
-Run "make all"
+Run "make"
 
 ```sh
-$ make all
+$ make
+```
+
+to install it run "make install"
+
+```sh
+$ make install
 ```
 
 Useful tricks:
-- build only *Linux* binaries
+- build all binaries (see Note1):
 ```sh
-$ make linux
+$ make binaries
 ```
-- build only *Windows* binaries
+
+Note1: to install all binaries ("make binaries") you need to first clone the OpenCL-Headers within the main folder:
+
 ```sh
-$ make windows
+$ git clone https://github.com/KhronosGroup/OpenCL-Headers deps/OpenCL-Headers/CL
 ```
+
+the tools/deps.sh script does not clone this repo automatically since for native compilation it is not needed.
 
 =
 Enjoy your fresh **oclHashcat** binaries ;)


### PR DESCRIPTION
This patch just updates BUILD.md . There are 2 major changes:
1. removed some target that do not exist anymore (and replaced them with the new targets if possible)
2. added a note about the need to clone OpenCL-Headers for "make binaries"

The reason is that make binaries needs the OpenCL-Headers s.t. e.g. windows binaries can be cross-compiled. This fix adds a note about OpenCL-Headers, explains how to clone it and also mentions the reason why tools/deps.sh does not automatically clone it.
Thx