### PR TITLE
added note about how to fix the 'cannot find -lOpenCL' error to BUILD.md

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -24,7 +24,7 @@ The following files are needed inside the *deps/tmp* directory:
     gdk_linux_amd64_352_55_release.run
     
 # Building oclHashcat
-First get a copy of **oclHashcat** repository
+First get a copy of the **oclHashcat** repository
 
 ```sh
 $ git clone https://github.com/hashcat/oclHashcat.git
@@ -49,7 +49,7 @@ $ make install
 ```
 
 Useful tricks:
-- build all binaries (see Note1):
+- build all binaries (see Note1 and Note2):
 ```sh
 $ make binaries
 ```
@@ -61,6 +61,20 @@ $ git clone https://github.com/KhronosGroup/OpenCL-Headers deps/OpenCL-Headers/C
 ```
 
 the tools/deps.sh script does not clone this repo automatically since for native compilation it is not needed.
+
+Note2: if you get an error like the following one for "make binaries"
+
+```sh
+/usr/bin/ld: cannot find -lOpenCL
+```
+
+the main reason is probably that the 32-bit version of libOpenCL.so was not found.
+
+A possible solution is to just symbolic link it (if the 32-bit version of libOpenCL.so.1 exists), for example:
+
+```sh
+sudo ln -s /usr/lib/i386-linux-gnu/libOpenCL.so.1 /usr/lib/i386-linux-gnu/libOpenCL.so
+```
 
 =
 Enjoy your fresh **oclHashcat** binaries ;)


### PR DESCRIPTION
this additional section within BUILD.md should address the problem on how to fix the 'cannot find -lOpenCL' error when using the "binaries" Makefile 

For the 32-bit version we have no libOpenCL.so (furthermore: in general we do not need it; for native compilation). This patch adds a note on how to get rid of the error message by suggesting a "ln -s" symbolic link to libOpenCL.so.1
thanks