### PR TITLE
updated gpu2cpu_rule_test script, we do not need the c++ here

### DIFF
--- a/tools/rules_test/Makefile
+++ b/tools/rules_test/Makefile
@@ -5,12 +5,12 @@
 
 GCC     := /usr/bin/x86_64-linux-gnu-gcc-4.6
 ROOT    := ../../
-CFLAGS  := -O2 -s -ansi -pipe -W -Wall -I$(ROOT)include/
+CFLAGS  := -O2 -s -ansi -pipe -W -Wall -std=c99 -I$(ROOT)include/
 LIBS    :=
 TARGET  := gpu2cpu_rule_test
-INCLUDE := $(ROOT)src/rp_gpu_on_cpu.cpp cpu_rules.cpp
+INCLUDE := $(ROOT)src/rp_gpu_on_cpu.c cpu_rules.c
 
-all: ${TARGET}.cpp
+all: ${TARGET}.c
 	${GCC} ${CFLAGS} ${INCLUDE} $< -o ${TARGET}.bin ${LIBS}
 
 clean:


### PR DESCRIPTION
We do not need the .cpp extension anymore.
The Makefile failed because the file (*.cpp) was replaced by the ansi c version (*.c).
Unfortunately, the Makefile was not up-to-date. This patch should allow the user to make the gpu2cpu_rule_test binary (again).
Thx 