### PR TITLE
install also the example scripts, place them into the doc folder

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -139,6 +139,7 @@ win64:          oclHashcat64.exe
 install: native
 	$(INSTALL) -m 755 -d                            $(DOCUMENT_FOLDER)
 	$(CP) -a docs/*                                 $(DOCUMENT_FOLDER)/
+	$(CP) -a example*.sh                            $(DOCUMENT_FOLDER)/
 	$(INSTALL) -m 755 -d                            $(DOCUMENT_FOLDER)/extra
 	$(CP) -a extra/*                                $(DOCUMENT_FOLDER)/extra/
 	$(INSTALL) -m 755 -d                            $(SHARED_FOLDER)


### PR DESCRIPTION
I think it makes sense to also install the example scripts example0.sh, example400.sh and example500.sh into the document folder (defaults to /usr/local/share/doc/oclHashcat/).

This way the user can easily find some useful examples on how to run oclHashcat.