### PR TITLE
pr #53 did not copy the example .hash and .dict files to the doc folder

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -140,6 +140,8 @@ install: native
 	$(INSTALL) -m 755 -d                            $(DOCUMENT_FOLDER)
 	$(CP) -a docs/*                                 $(DOCUMENT_FOLDER)/
 	$(CP) -a example*.sh                            $(DOCUMENT_FOLDER)/
+	$(CP) -a example*.hash                          $(DOCUMENT_FOLDER)/
+	$(INSTALL) -m 644 example.dict                  $(DOCUMENT_FOLDER)/
 	$(INSTALL) -m 755 -d                            $(DOCUMENT_FOLDER)/extra
 	$(CP) -a extra/*                                $(DOCUMENT_FOLDER)/extra/
 	$(INSTALL) -m 755 -d                            $(SHARED_FOLDER)


### PR DESCRIPTION
Pull request #53 did not correctly copy the *.hash and *.dict files to the doc folder. They are both needed to successfully run the tests.