### PR TITLE
updated tab completion

### DIFF
--- a/extra/tab_completion/install
+++ b/extra/tab_completion/install
@@ -133,7 +133,7 @@ if [ -d "${COMPGENFOLDER}" ]; then
 
   # remove the old version of oclHashcat64.sh (was renamed to just oclHashcat.sh)
 
-  rm -rf "${COMPGENTARGET}"/oclHashcat64.sh
+  rm -f "${COMPGENTARGET}"/oclHashcat64.sh
 
   # copy the script to target folder
 

--- a/extra/tab_completion/install
+++ b/extra/tab_completion/install
@@ -94,7 +94,9 @@ is_child=0
 
 if ! is_root; then
 
-   sudo ${BASH_SOURCE[0]} ${was_sourced}
+  echo "Warning: root permissions are required to install the tab completion script into the protected '${COMPGENFOLDER}' folder"
+
+  sudo ${BASH_SOURCE[0]} ${was_sourced}
 
   ret=${?}
 
@@ -128,6 +130,10 @@ then
 fi
 
 if [ -d "${COMPGENFOLDER}" ]; then
+
+  # remove the old version of oclHashcat64.sh (was renamed to just oclHashcat.sh)
+
+  rm -rf "${COMPGENTARGET}"/oclHashcat64.sh
 
   # copy the script to target folder
 

--- a/extra/tab_completion/oclHashcat.sh
+++ b/extra/tab_completion/oclHashcat.sh
@@ -169,7 +169,7 @@ _oclHashcat_contains ()
 
 _oclHashcat ()
 {
-  local VERSION=1.20
+  local VERSION=2.10
 
   local HASH_MODES="0 10 11 12 20 21 22 23 30 40 50 60 100 101 110 111 112 120 121 122 124 130 131 132 133 140 141 150 160 190 200 300 400 500 501 900 1000 1100 1400 1410 1420 1421 1430 1440 1441 1450 1460 1500 1600 1700 1710 1711 1720 1722 1730 1731 1740 1750 1760 1800 2100 2400 2410 2500 2600 2611 2612 2711 2811 3000 3100 3200 3710 3711 3800 4300 4400 4500 4700 4800 4900 5000 5100 5200 5300 5400 5500 5600 5700 5800 6000 6100 6211 6212 6213 6221 6222 6223 6231 6232 6233 6241 6242 6243 6300 6400 6500 6600 6700 6800 6900 7100 7200 7300 7400 7500 7600 7700 7800 7900 8000 8100 8200 8300 8400 8500 8600 8700 8800 8900 9000 9100 9200 9300 9400 9500 9600 9700 9710 9720 9800 9810 9820 9900 10000 10100 10200 10300 10400 10410 10420 10500 10600 10700 10800 10900 11000 11100 11200 11300 11400 11500 11600 11700 11800 11900 12000 12100 12200 12300 12400 12500 12600 12700 12800"
   local ATTACK_MODES="0 1 3 6 7"
@@ -262,6 +262,34 @@ _oclHashcat ()
       _oclHashcat_get_permutations ${num_devices}
 
       COMPREPLY=($(compgen -W "${oclHashcat_devices_permutation}" -- ${cur}))
+      return 0
+      ;;
+
+    --opencl-platform)
+      local icd_list=$(ls -1 /etc/OpenCL/vendors/*.icd 2> /dev/null)
+
+      local architecture=$(getconf LONG_BIT 2> /dev/null)
+
+      if [ -z "${architecture}" ]; then
+        return 0
+      fi
+
+      # filter the icd_list (do not show 32 bit on 64bit systems and vice versa)
+
+      if [ "${architecture}" -eq 64 ]; then
+
+        icd_list=$(echo "${icd_list}" | grep -v "32.icd")
+
+      else
+
+        icd_list=$(echo "${icd_list}" | grep -v "64.icd")
+
+      fi
+
+      local number_icds=$(seq 1 $(echo "${icd_list}" | wc -l))
+
+      COMPREPLY=($(compgen -W "${number_icds}" -- ${cur}))
+
       return 0
       ;;
 


### PR DESCRIPTION
This commit just updated the tab completion script.
It checks whether the old "oclHashcat64.bin" is still present and if so removes it.
Tab completion was also added to the --opencl-platform option.