### PR TITLE
updated MIT license year

### DIFF
--- a/docs/license.txt
+++ b/docs/license.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Jens Steube
+Copyright (c) 2015-2016 Jens Steube
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request just updated the year within the MIT license file.

I did try to find other occurences of "2015", i.e. years that must be updated, but besides this one didn't find any other. We should be good with this fix.

Thanks