### PR TITLE
added --opencl-platform check, reject numbers > number of OpenCL platforms

### DIFF
--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -12300,7 +12300,12 @@ int main (int argc, char **argv)
       return (-1);
     }
 
-    uint CL_platform_sel = 0;
+    uint CL_platform_sel = 1;
+
+    if (opencl_platform != NULL)
+    {
+      CL_platform_sel = atoi (opencl_platform);
+    }
 
     if (CL_platforms_cnt > 1)
     {
@@ -12330,20 +12335,28 @@ int main (int argc, char **argv)
       }
       else
       {
-        CL_platform_sel = atoi (opencl_platform);
-
         if (CL_platform_sel > CL_platforms_cnt)
         {
           log_error ("ERROR: invalid OpenCL platforms selected");
 
           return (-1);
         }
-
-        // user does not count with zero
-
-        CL_platform_sel -= 1;
       }
     }
+    else
+    {
+      if (CL_platform_sel != 1)
+      {
+        log_error ("ERROR: OpenCL platform number %d not available", CL_platform_sel);
+
+        return (-1);
+      }
+    }
+
+    // zero-indexed: not starting to count at 1, as user does
+
+    CL_platform_sel -= 1;
+
 
     cl_platform_id CL_platform = CL_platforms[CL_platform_sel];
 

--- a/src/oclHashcat.c
+++ b/src/oclHashcat.c
@@ -12335,6 +12335,13 @@ int main (int argc, char **argv)
       }
       else
       {
+        if (CL_platform_sel < 1)
+        {
+          log_error ("ERROR: --opencl-platform < 1");
+
+          return (-1);
+        }
+
         if (CL_platform_sel > CL_platforms_cnt)
         {
           log_error ("ERROR: invalid OpenCL platforms selected");
@@ -12347,7 +12354,7 @@ int main (int argc, char **argv)
     {
       if (CL_platform_sel != 1)
       {
-        log_error ("ERROR: OpenCL platform number %d not available", CL_platform_sel);
+        log_error ("ERROR: OpenCL platform number %d is not available", CL_platform_sel);
 
         return (-1);
       }


### PR DESCRIPTION
This additional check rejects every --opencl-platform value that is larger than the number of acutal OpenCL platform.
Currently, there is no check about what (--opencl-platform) values are specified by the user and therefore the --opencl-platform value was silently ignored whenever the number of OpenCL platforms was for instance exactly 1 (only 1 GPU for example).
Thx